### PR TITLE
fix: CLI arg support and infinite loop on empty CSV

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -1,38 +1,60 @@
+import argparse
 import csv
 
+
 def load_employees(file_path):
-    employees = []
+    """Load employees from a CSV file. Returns (employees, error) tuple."""
     try:
-        with open(file_path) as csv_file:
+        with open(file_path, encoding="utf-8") as csv_file:
             reader = csv.DictReader(csv_file)
+            employees = []
             for row in reader:
-                # Validate the presence of expected keys
                 if not all(key in row for key in ['EmployeeID', 'Name', 'Department', 'Position', 'Salary']):
-                    raise ValueError("File format is incorrect or corrupted.")
+                    return [], "File format is incorrect or corrupted."
                 employees.append(row)
-        print(f"Successfully loaded {len(employees)} employees")
+        return employees, None
     except FileNotFoundError:
-        print(f"Error: File '{file_path}' not found.")
-    except ValueError as ve:
-        print(f"Error: {ve}")
+        return [], f"File '{file_path}' not found."
     except Exception as error:
-        print(f"An unexpected error occurred: {error}")
-    return employees
+        return [], f"An unexpected error occurred: {error}"
+
+
+def print_employees(employees):
+    for emp in employees:
+        print(f"ID: {emp['EmployeeID']}, Name: {emp['Name']}, "
+              f"Department: {emp['Department']}, "
+              f"Position: {emp['Position']}, Salary: {emp['Salary']}")
+
 
 def main():
-    while True:
-        file_path = input("Enter the path to the employees file: ").strip()
-        employees = load_employees(file_path)
+    parser = argparse.ArgumentParser(description="Load and display employees from a CSV file.")
+    parser.add_argument("file", nargs="?", help="Path to the employees CSV file")
+    args = parser.parse_args()
 
-        if employees:
-            print("Employees loaded successfully:")
-            for emp in employees:
-                print(f"ID: {emp['EmployeeID']}, Name: {emp['Name']}, "
-                      f"Department: {emp['Department']}, "
-                      f"Position: {emp['Position']}, Salary: {emp['Salary']}")
-            break  # Exit the loop if employees are loaded successfully
-        else:
-            print("Failed to load employees. Please try again.")
+    if args.file:
+        employees, error = load_employees(args.file)
+        if error:
+            print(f"Error: {error}")
+            return
+        if not employees:
+            print("No employee records found in the file.")
+            return
+        print(f"Successfully loaded {len(employees)} employees:")
+        print_employees(employees)
+    else:
+        while True:
+            file_path = input("Enter the path to the employees file: ").strip()
+            employees, error = load_employees(file_path)
+            if error:
+                print(f"Error: {error} Please try again.")
+                continue
+            if not employees:
+                print("No employee records found in the file.")
+                break
+            print(f"Successfully loaded {len(employees)} employees:")
+            print_employees(employees)
+            break
+
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
## Issues fixed

### 1. Infinite loop on valid-but-empty CSV
`main()` used `if employees:` to decide whether to retry, but `load_employees` returned `[]` for both a missing file **and** a file that exists but has zero data rows. A user pointing at an empty (but valid) CSV would get a `"Failed to load employees. Please try again."` loop with no way out short of Ctrl-C.

**Fix:** `load_employees` now returns `(employees, error)`. The caller distinguishes between a load error (retry prompt) and a successfully-loaded-but-empty file (print a message and exit cleanly).

### 2. No CLI argument — always required interactive input
The script could not be run non-interactively, making it impossible to use in scripts, tests, or pipelines.

**Fix:** Added `argparse` with an optional positional `file` argument. When provided, the script runs headlessly (`python src/main.py Data/employees.csv`); without it, the interactive prompt loop runs as before.

### 3. Implicit file encoding
`open(file_path)` used the platform's default locale encoding, which varies across operating systems and can cause silent failures on non-ASCII names.

**Fix:** Changed to `open(file_path, encoding="utf-8")`.