### PR TITLE
chore: repo hardening round 2 (.gitignore)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,35 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# Distribution / packaging
+build/
+dist/
+*.egg-info/
+.eggs/
+
+# Virtual environments
+.venv/
+venv/
+env/
+ENV/
+
+# Test / coverage artifacts
+.pytest_cache/
+.coverage
+htmlcov/
+.tox/
+
+# Editors / IDEs
+.idea/
+.vscode/
+*.swp
+*.swo
+
+# OS files
+.DS_Store
+Thumbs.db
+
+# Logs
+*.log


### PR DESCRIPTION
Adds a language-appropriate root .gitignore covering Python bytecode/caches, virtualenvs, build artifacts, IDE/editor files (.idea/, .vscode/), and OS files. This change is purely additive and non-breaking: it adds one new file and modifies no existing files.